### PR TITLE
Fix addUser dropdown now shows all users except current

### DIFF
--- a/controllers/lists.js
+++ b/controllers/lists.js
@@ -24,7 +24,6 @@ module.exports = {
 			const list = await List.findById(req.params.id)
 				.populate('invitedUsers')
 				.lean()
-			const users = await User.find()
 
 			// Check if list exists
 			if (!list) {
@@ -51,6 +50,9 @@ module.exports = {
 				listId: req.params.id,
 				completed: false,
 			})
+
+			// Get all users except current user to populate addUser dropdown
+			const users = await User.find({ _id: { $ne: req.user._id } })
 
 			res.render('todos.ejs', {
 				listName: list.name,

--- a/views/todos.ejs
+++ b/views/todos.ejs
@@ -76,7 +76,7 @@
                         <% users.forEach( el => { %>
                             <option value="<%= el.userName %>"><%= el.userName %></option> 
                         <% }) %>
-                            <option value="<%= user.userName %>" selected>Select A User</option>                             
+                            <option value="select a user" disabled selected>Select A User</option>                             
                     </select> 
                 </form>
 


### PR DESCRIPTION
The drop down to share your list with another user now shows all users except current user(aka isOwner). 